### PR TITLE
Raise error if invalid cloud ID or installation code

### DIFF
--- a/eagle200_reader/eagle200_reader.py
+++ b/eagle200_reader/eagle200_reader.py
@@ -82,6 +82,7 @@ class EagleReader:
         devices = []
         response = requests.post("http://" + self.ip_addr +
             "/cgi-bin/post_manager", HTTP_DEVICE_LIST, auth=(self.cloud_id, self.install_code), timeout=2)
+        response.raise_for_status()
         tree = ET.fromstring(response.content)
         for node in tree.iter('HardwareAddress'):
             devices.append(node.text)


### PR DESCRIPTION
Quick fix to raise an error if invalid cloud ID / installation code provided. This will allow us to provide feedback to the user when they enter their credentials.